### PR TITLE
fix log color

### DIFF
--- a/script/deploy
+++ b/script/deploy
@@ -11,21 +11,21 @@ NC='\033[0m' # No Color
 # Utility functions
 print_info() {
     if [ "$QUIET_MODE" != "true" ]; then
-        printf '%s[INFO]%s %s\n' "${GREEN}" "${NC}" "$1"
+        printf "\033[0;32m[INFO]\033[0m %s\n" "$1"
     fi
 }
 
 print_warning() {
-    printf '%s[WARNING]%s %s\n' "${YELLOW}" "${NC}" "$1"
+    printf "\033[1;33m[WARNING]\033[0m %s\n" "$1"
 }
 
 print_error() {
-    printf '%s[ERROR]%s %s\n' "${RED}" "${NC}" "$1"
+    printf "\033[0;31m[ERROR]\033[0m %s\n" "$1"
 }
 
 print_command() {
     if [ "$QUIET_MODE" != "true" ]; then
-        printf '%s[COMMAND]%s %s\n' "${YELLOW}" "${NC}" "$1"
+        printf "\033[1;33m[COMMAND]\033[0m %s\n" "$1"
     fi
 }
 


### PR DESCRIPTION
This pull request updates the color formatting for log messages in the `script/deploy` utility functions. The changes replace the use of shell variables for color codes with direct ANSI escape sequences in the `printf` statements, simplifying how colored output is generated. No functional behavior is changed; only the implementation of color formatting is updated.